### PR TITLE
fix: misuse of unbuffered os.Signal

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	ch := make(chan os.Signal)
+	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, syscall.SIGTERM)
 
 	repl, err := menu.NewREPL()


### PR DESCRIPTION
This fixes `./main.go:13:2: misuse of unbuffered os.Signal channel as argument to signal.Notify` reported by running `go vet ./...` with go 1.17.

This should unblock enabling CI here - https://github.com/libp2p/repl/pull/10

I have seen it approach this way here for example - https://github.com/libp2p/docs/blob/9118df6319900cf00beb724df9f149ee00d13218/content/tutorials/getting-started/go.md#wait-for-a-signal